### PR TITLE
Add syscall tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,6 @@ install:
 	wget 'https://github.com/nervosnetwork/ckb-standalone-debugger/releases/download/v0.111.0/ckb-debugger-linux-x64.tar.gz'
 	tar zxvf ckb-debugger-linux-x64.tar.gz
 	mv ckb-debugger ~/.cargo/bin/ckb-debugger
-	make -f tests/ckb_js_tests/Makefile install_ubuntu
+	make -f tests/ckb_js_tests/Makefile install-lua
 
 .phony: all clean

--- a/quickjs/ckb_module.c
+++ b/quickjs/ckb_module.c
@@ -106,8 +106,8 @@ static JSValue syscall_load(JSContext *ctx, LoadData *data) {
     uint64_t len = data->length;
     err = data->func(addr, &len, data);
     CHECK(err);
-    CHECK2(len >= data->length, SyscallErrorUnknown);
-    ret = JS_NewArrayBuffer(ctx, addr, data->length, my_free, addr, false);
+    int real_len = len < data->length ? len : data->length;
+    ret = JS_NewArrayBuffer(ctx, addr, real_len, my_free, addr, false);
 exit:
     if (err != 0) {
         return JS_EXCEPTION;

--- a/quickjs/ckb_module.c
+++ b/quickjs/ckb_module.c
@@ -298,8 +298,9 @@ static JSValue syscall_exec_cell(JSContext *ctx, JSValueConst this_value, int ar
     uint8_t code_hash[32];
 
     JSValue buffer = JS_GetTypedArrayBuffer(ctx, argv[0], NULL, NULL, NULL);
+    CHECK2(!JS_IsException(buffer), SyscallErrorArgument);
     uint8_t *p = JS_GetArrayBuffer(ctx, &code_hash_len, buffer);
-    CHECK2(code_hash_len == 32, -1);
+    CHECK2(code_hash_len == 32 && p != NULL, -1);
     memcpy(code_hash, p, 32);
 
     err = JS_ToUint32(ctx, &hash_type, argv[1]);
@@ -389,8 +390,9 @@ static JSValue syscall_spawn_cell(JSContext *ctx, JSValueConst this_value, int a
     uint8_t code_hash[32];
 
     JSValue buffer = JS_GetTypedArrayBuffer(ctx, argv[0], NULL, NULL, NULL);
+    CHECK2(!JS_IsException(buffer), SyscallErrorArgument);
     uint8_t *p = JS_GetArrayBuffer(ctx, &code_hash_len, buffer);
-    CHECK2(code_hash_len == 32, -1);
+    CHECK2(code_hash_len == 32 && p != NULL, -1);
     memcpy(code_hash, p, 32);
 
     err = JS_ToUint32(ctx, &hash_type, argv[1]);
@@ -434,7 +436,9 @@ static JSValue syscall_set_content(JSContext *ctx, JSValueConst this_value, int 
     int err = 0;
     size_t content_length = 0;
     JSValue buffer = JS_GetTypedArrayBuffer(ctx, argv[0], NULL, NULL, NULL);
+    CHECK2(!JS_IsException(buffer), SyscallErrorArgument);
     uint8_t *content = JS_GetArrayBuffer(ctx, &content_length, buffer);
+    CHECK2(content != NULL, SyscallErrorUnknown);
     uint64_t content_length2 = (uint64_t)content_length;
     err = ckb_set_content(content, &content_length2);
     CHECK(err);

--- a/quickjs/ckb_module.c
+++ b/quickjs/ckb_module.c
@@ -297,7 +297,8 @@ static JSValue syscall_exec_cell(JSContext *ctx, JSValueConst this_value, int ar
     const char *passed_argv[256] = {0};
     uint8_t code_hash[32];
 
-    uint8_t *p = JS_GetArrayBuffer(ctx, &code_hash_len, argv[0]);
+    JSValue buffer = JS_GetTypedArrayBuffer(ctx, argv[0], NULL, NULL, NULL);
+    uint8_t *p = JS_GetArrayBuffer(ctx, &code_hash_len, buffer);
     CHECK2(code_hash_len == 32, -1);
     memcpy(code_hash, p, 32);
 
@@ -387,7 +388,8 @@ static JSValue syscall_spawn_cell(JSContext *ctx, JSValueConst this_value, int a
     int8_t exit_code = 0;
     uint8_t code_hash[32];
 
-    uint8_t *p = JS_GetArrayBuffer(ctx, &code_hash_len, argv[0]);
+    JSValue buffer = JS_GetTypedArrayBuffer(ctx, argv[0], NULL, NULL, NULL);
+    uint8_t *p = JS_GetArrayBuffer(ctx, &code_hash_len, buffer);
     CHECK2(code_hash_len == 32, -1);
     memcpy(code_hash, p, 32);
 
@@ -431,7 +433,8 @@ exit:
 static JSValue syscall_set_content(JSContext *ctx, JSValueConst this_value, int argc, JSValueConst *argv) {
     int err = 0;
     size_t content_length = 0;
-    uint8_t *content = JS_GetArrayBuffer(ctx, &content_length, argv[0]);
+    JSValue buffer = JS_GetTypedArrayBuffer(ctx, argv[0], NULL, NULL, NULL);
+    uint8_t *content = JS_GetArrayBuffer(ctx, &content_length, buffer);
     uint64_t content_length2 = (uint64_t)content_length;
     err = ckb_set_content(content, &content_length2);
     CHECK(err);

--- a/quickjs/mocked.c
+++ b/quickjs/mocked.c
@@ -1,12 +1,15 @@
 
 
 #include "mocked.h"
+#include "ckb_syscall_apis.h"
+
 int fesetround(int _round) { return 0; }
 
 int fegetround() { return 0; }
 
-// TODO: add panic code to following functions
-struct tm *localtime_r(const time_t *a, struct tm *b) { return 0; }
+struct tm *localtime_r(const time_t *a, struct tm *b) { 
+    return 0; 
+}
 int gettimeofday(struct timeval *restrict tv, struct timezone *restrict tz) {
     return 0;
 }

--- a/quickjs/std_module.c
+++ b/quickjs/std_module.c
@@ -155,9 +155,7 @@ JSModuleDef *js_module_loader(JSContext *ctx, const char *module_name, void *opa
     return m;
 }
 
-static int js_module_dummy_init(JSContext *ctx, JSModuleDef *m) {
-    return 0;
-}
+static int js_module_dummy_init(JSContext *ctx, JSModuleDef *m) { return 0; }
 
 JSModuleDef *js_module_dummy_loader(JSContext *ctx, const char *module_name, void *opaque) {
     return JS_NewCModule(ctx, module_name, js_module_dummy_init);

--- a/tests/basic/Makefile
+++ b/tests/basic/Makefile
@@ -1,14 +1,15 @@
 
 CKB-DEBUGGER := ckb-debugger
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+BIN_PATH = $(ROOT_DIR)/../../build/ckb-js-vm
 MAX-CYCLES ?= 2000000000
 
 define run
-	$(CKB-DEBUGGER) --max-cycles $(MAX-CYCLES) --read-file $(ROOT_DIR)/$(1) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -r  2>&1 | fgrep 'Run result: 0'
+	$(CKB-DEBUGGER) --max-cycles $(MAX-CYCLES) --read-file $(ROOT_DIR)/$(1) --bin $(BIN_PATH) -- -r  2>&1 | fgrep 'Run result: 0'
 endef
 
 define debug
-	$(CKB-DEBUGGER) --max-cycles $(MAX-CYCLES) --read-file $(ROOT_DIR)/$(1) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -r
+	$(CKB-DEBUGGER) --max-cycles $(MAX-CYCLES) --read-file $(ROOT_DIR)/$(1) --bin $(BIN_PATH) -- -r
 endef
 
 all: qjs-tests syntax-error log syscalls assert
@@ -22,20 +23,20 @@ qjs-tests:
 	$(call run,test_bignum.js)
 
 log:
-	$(CKB-DEBUGGER) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -e "console.log(scriptArgs[0], scriptArgs[1]);" hello world
+	$(CKB-DEBUGGER) --bin $(BIN_PATH) -- -e "console.log(scriptArgs[0], scriptArgs[1]);" hello world
 
 
 assert:
-	$(CKB-DEBUGGER) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -e "console.assert(true);"
-	$(CKB-DEBUGGER) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -e "console.assert(true); console.assert(false); " || echo "should fail"
+	$(CKB-DEBUGGER) --bin $(BIN_PATH) -- -e "console.assert(true);"
+	$(CKB-DEBUGGER) --bin $(BIN_PATH) -- -e "console.assert(true); console.assert(false); " || echo "should fail"
 
 syntax-error:
-	$(CKB-DEBUGGER) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -e "ASDF" | grep "ReferenceError: 'ASDF' is not defined"
+	$(CKB-DEBUGGER) --bin $(BIN_PATH) -- -e "ASDF" | grep "ReferenceError: 'ASDF' is not defined"
 
 syscalls:
-	$(CKB-DEBUGGER) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -e "console.log(ckb);"
-	$(CKB-DEBUGGER) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -e "ckb.exit(0);"
-	$(CKB-DEBUGGER) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -e 'ckb.debug("hello, ckb");'
-	$(CKB-DEBUGGER) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -e 'console.log(ckb.vm_version(), ckb.current_cycles())'
-	$(CKB-DEBUGGER) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -e 'console.log(ckb.SOURCE_INPUT, ckb.SOURCE_OUTPUT, ckb.CELL_FIELD_OCCUPIED_CAPACITY)'
-	$(CKB-DEBUGGER) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -e 'console.log(100.1, ckb.SOURCE_GROUP_INPUT, ckb.SOURCE_GROUP_OUTPUT)'
+	$(CKB-DEBUGGER) --bin $(BIN_PATH) -- -e "console.log(ckb);"
+	$(CKB-DEBUGGER) --bin $(BIN_PATH) -- -e "ckb.exit(0);"
+	$(CKB-DEBUGGER) --bin $(BIN_PATH) -- -e 'ckb.debug("hello, ckb");'
+	$(CKB-DEBUGGER) --bin $(BIN_PATH) -- -e 'console.log(ckb.vm_version(), ckb.current_cycles())'
+	$(CKB-DEBUGGER) --bin $(BIN_PATH) -- -e 'console.log(ckb.SOURCE_INPUT, ckb.SOURCE_OUTPUT, ckb.CELL_FIELD_OCCUPIED_CAPACITY)'
+	$(CKB-DEBUGGER) --bin $(BIN_PATH) -- -e 'console.log(100.1, ckb.SOURCE_GROUP_INPUT, ckb.SOURCE_GROUP_OUTPUT)'

--- a/tests/ckb_js_tests/.gitignore
+++ b/tests/ckb_js_tests/.gitignore
@@ -1,2 +1,3 @@
 target/
 tx.json
+syscall.json

--- a/tests/ckb_js_tests/.gitignore
+++ b/tests/ckb_js_tests/.gitignore
@@ -1,3 +1,1 @@
 target/
-tx.json
-syscall.json

--- a/tests/ckb_js_tests/Makefile
+++ b/tests/ckb_js_tests/Makefile
@@ -1,7 +1,7 @@
 CKB_DEBUGGER ?= ckb-debugger
 MAX_CYCLES ?= 2000000000
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-CKB_JS_VM_BIN_PATH = $(ROOT_DIR)/../../build/ckb-js-vm
+BIN_PATH = $(ROOT_DIR)/../../build/ckb-js-vm
 
 all: \
 	cargo_test \
@@ -17,10 +17,10 @@ build/testdata_fs_modules.bin: test_data/fs_module/main.js test_data/fs_module/f
 
 fs_bytecode:
 	mkdir -p ../../build/bytecode
-	$(CKB_DEBUGGER) --read-file test_data/fs_module/main.js --bin $(CKB_JS_VM_BIN_PATH) -- -c | awk '/Run result: 0/{exit} {print}' | xxd -r -p > ../../build/bytecode/main.bc
-	$(CKB_DEBUGGER) --read-file test_data/fs_module/fib_module.js --bin $(CKB_JS_VM_BIN_PATH) -- -c | awk '/Run result: 0/{exit} {print}' | xxd -r -p > ../../build/bytecode/fib_module.bc
+	$(CKB_DEBUGGER) --read-file test_data/fs_module/main.js --bin $(BIN_PATH) -- -c | awk '/Run result: 0/{exit} {print}' | xxd -r -p > ../../build/bytecode/main.bc
+	$(CKB_DEBUGGER) --read-file test_data/fs_module/fib_module.js --bin $(BIN_PATH) -- -c | awk '/Run result: 0/{exit} {print}' | xxd -r -p > ../../build/bytecode/fib_module.bc
 	cd ../../build/bytecode && lua ../../tools/fs.lua pack ../../build/testdata_fs_modules_bc.bin main.bc fib_module.bc
-	$(CKB_DEBUGGER) --max-cycles $(MAX_CYCLES) --read-file ../../build/testdata_fs_modules_bc.bin --bin $(CKB_JS_VM_BIN_PATH) -- -f -r 2>&1 | fgrep 'Run result: 0'
+	$(CKB_DEBUGGER) --max-cycles $(MAX_CYCLES) --read-file ../../build/testdata_fs_modules_bc.bin --bin $(BIN_PATH) -- -f -r 2>&1 | fgrep 'Run result: 0'
 
 file_system: build/testdata_fs_modules.bin
 	cargo run --bin default_by_cell | $(CKB_DEBUGGER) -s lock --tx-file=- --read-file ../../$^ -- -f -r  2>&1 | fgrep 'Run result: 0'

--- a/tests/ckb_js_tests/Makefile
+++ b/tests/ckb_js_tests/Makefile
@@ -1,25 +1,19 @@
 CKB_DEBUGGER ?= ckb-debugger
 MAX_CYCLES ?= 2000000000
-
-CKB_JS_VM_BIN_PATH = ../../build/ckb-js-vm
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+CKB_JS_VM_BIN_PATH = $(ROOT_DIR)/../../build/ckb-js-vm
 
 all: \
 	cargo_test \
-	default_by_cell \
-	fs_def_cell_module
-
+	file_system \
+	syscall \
+	fs_def_cell_module_bytecode
+	
 cargo_test:
 	cargo test
 
-default_by_cell:
-	cargo run --bin default_by_cell > tx.json
-	${CKB_DEBUGGER} --tx-file=tx.json -s lock
-
 build/testdata_fs_modules.bin: test_data/fs_module/main.js test_data/fs_module/fib_module.js
 	cd test_data/fs_module && lua ../../../../tools/fs.lua pack ../../../../$@ main.js fib_module.js
-
-fs_def_cell_module: build/testdata_fs_modules.bin
-	$(CKB_DEBUGGER) --max-cycles $(MAX_CYCLES) --read-file ../../$? --bin $(CKB_JS_VM_BIN_PATH) -- -f -r  2>&1 | fgrep 'Run result: 0'
 
 fs_def_cell_module_bytecode:
 	mkdir -p ../../build/bytecode
@@ -28,7 +22,13 @@ fs_def_cell_module_bytecode:
 	cd ../../build/bytecode && lua ../../tools/fs.lua pack ../../build/testdata_fs_modules_bc.bin main.bc fib_module.bc
 	$(CKB_DEBUGGER) --max-cycles $(MAX_CYCLES) --read-file ../../build/testdata_fs_modules_bc.bin --bin $(CKB_JS_VM_BIN_PATH) -- -f -r 2>&1 | fgrep 'Run result: 0'
 
-install_ubuntu:
+file_system: build/testdata_fs_modules.bin
+	cargo run --bin default_by_cell | $(CKB_DEBUGGER) -s lock --tx-file=- --read-file ../../$^ -- -f -r  2>&1 | fgrep 'Run result: 0'
+
+syscall:
+	cargo run --bin syscall | $(CKB_DEBUGGER) --tx-file=- -s lock
+
+install-lua:
 	sudo apt install lua5.4
 
 clean:

--- a/tests/ckb_js_tests/Makefile
+++ b/tests/ckb_js_tests/Makefile
@@ -7,18 +7,18 @@ all: \
 	cargo_test \
 	file_system \
 	syscall \
-	fs_def_cell_module_bytecode
-	
+	fs_bytecode
+
 cargo_test:
 	cargo test
 
 build/testdata_fs_modules.bin: test_data/fs_module/main.js test_data/fs_module/fib_module.js
 	cd test_data/fs_module && lua ../../../../tools/fs.lua pack ../../../../$@ main.js fib_module.js
 
-fs_def_cell_module_bytecode:
+fs_bytecode:
 	mkdir -p ../../build/bytecode
-	$(CKB_DEBUGGER) --read-file test_data/fs_module/main.js --bin $(CKB_JS_VM_BIN_PATH) -- -c | head -n -3 | xxd -r -p > ../../build/bytecode/main.bc
-	$(CKB_DEBUGGER) --read-file test_data/fs_module/fib_module.js --bin $(CKB_JS_VM_BIN_PATH) -- -c | head -n -3 | xxd -r -p > ../../build/bytecode/fib_module.bc
+	$(CKB_DEBUGGER) --read-file test_data/fs_module/main.js --bin $(CKB_JS_VM_BIN_PATH) -- -c | awk '/Run result: 0/{exit} {print}' | xxd -r -p > ../../build/bytecode/main.bc
+	$(CKB_DEBUGGER) --read-file test_data/fs_module/fib_module.js --bin $(CKB_JS_VM_BIN_PATH) -- -c | awk '/Run result: 0/{exit} {print}' | xxd -r -p > ../../build/bytecode/fib_module.bc
 	cd ../../build/bytecode && lua ../../tools/fs.lua pack ../../build/testdata_fs_modules_bc.bin main.bc fib_module.bc
 	$(CKB_DEBUGGER) --max-cycles $(MAX_CYCLES) --read-file ../../build/testdata_fs_modules_bc.bin --bin $(CKB_JS_VM_BIN_PATH) -- -f -r 2>&1 | fgrep 'Run result: 0'
 

--- a/tests/ckb_js_tests/src/bin/syscall.rs
+++ b/tests/ckb_js_tests/src/bin/syscall.rs
@@ -1,0 +1,9 @@
+use ckb_js_tests::read_tx_template;
+
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tx = read_tx_template("templates/syscall.json")?;
+
+    let json = serde_json::to_string_pretty(&tx).unwrap();
+    println!("{}", json);
+    Ok(())
+}

--- a/tests/ckb_js_tests/templates/syscall.json
+++ b/tests/ckb_js_tests/templates/syscall.json
@@ -1,0 +1,63 @@
+{
+  "mock_info": {
+    "inputs": [
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x0000{{ ref_type js-code-file }}01",
+            "code_hash": "0x{{ ref_type ckb-js-vm }}",
+            "hash_type": "type"
+          },
+          "type": null
+        },
+        "data": "0x"
+      }
+    ],
+    "cell_deps": [
+      {
+        "output": {
+          "capacity": "0x10000000",            
+          "lock": {
+              "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+              "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "hash_type": "data1"
+          },
+          "type": "{{ def_type ckb-js-vm }}"
+        },
+        "data": "0x{{ data ../../../build/ckb-js-vm }}"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+              "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+              "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "hash_type": "data1"
+          },
+          "type": "{{ def_type js-code-file }}"
+        },
+        "data": "0x{{ data ../test_data/syscall.js }}"
+      }
+    ],
+    "header_deps": []
+  },
+  "tx": {
+    "outputs": [
+      {
+        "capacity": "0x0",
+        "lock": {
+          "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+          "code_hash": "0x{{ ref_type ckb-js-vm }}",
+          "hash_type": "type"
+        }
+      }
+    ],
+    "witnesses": [
+      "0x0001020304050607"
+    ],
+    "outputs_data": [
+      "0x0001020304050607"
+    ]
+  }
+}

--- a/tests/ckb_js_tests/test_data/syscall.js
+++ b/tests/ckb_js_tests/test_data/syscall.js
@@ -1,0 +1,118 @@
+
+
+const ARRAY8 = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+
+function expect_array(a, b) {
+    if (a.byteLength != b.length) {
+        console.assert(
+            false, `expect_array failed: length mismatched, ${a} VS ${b}`);
+    }
+    for (let i = 0; i < a.length; i++) {
+        console.assert(a[i] === b[i], `expect_array failed at index ${i}`);
+    }
+}
+
+function must_throw_exception(f) {
+    let has_exception = false;
+    try {
+        f();
+    } catch (e) {
+        has_exception = true;
+    }
+    console.assert(has_exception, 'Error, no exception found');
+}
+
+function test_partial_loading(load_func) {
+    console.log('test_partial_loading ...');
+    let data = load_func(0, ckb.SOURCE_OUTPUT);
+    expect_array(data, ARRAY8);
+    let length = load_func(0, ckb.SOURCE_OUTPUT, 0);
+    console.assert(length === 8, 'length != 8');
+    length = load_func(0, ckb.SOURCE_OUTPUT, 0, 1);
+    console.assert(length === 7, 'length != 7');
+    data = load_func(0, ckb.SOURCE_OUTPUT, 7);
+    expect_array(data, ARRAY8.slice(0, 7));
+    data = load_func(0, ckb.SOURCE_OUTPUT, 7, 1);
+    expect_array(data, ARRAY8.slice(1, 8));
+
+    must_throw_exception(() => {
+        load_func(1001n, ckb.SOURCE_OUTPUT);
+    });
+    must_throw_exception(() => {
+        load_func(0, ckb.SOURCE_OUTPUT + 1000n);
+    });
+    console.log('test_partial_loading done');
+}
+
+
+function test_partial_loading_without_comparing(load_func) {
+    console.log('test_partial_loading_without_comparing ...');
+    let data = load_func(0, ckb.SOURCE_OUTPUT);
+    console.assert(data);
+    let length = load_func(0, ckb.SOURCE_OUTPUT, 0);
+    console.assert(length > 0);
+    length = load_func(0, ckb.SOURCE_OUTPUT, 0, 1);
+    console.assert(length > 0);
+    data = load_func(0, ckb.SOURCE_OUTPUT, 7);
+    console.assert(data);
+    data = load_func(0, ckb.SOURCE_OUTPUT, 7, 1);
+    console.assert(data);
+
+    must_throw_exception(() => {
+        load_func(1001n, ckb.SOURCE_OUTPUT);
+    });
+    must_throw_exception(() => {
+        load_func(0, ckb.SOURCE_OUTPUT + 1000n);
+    });
+    console.log('test_partial_loading done');
+}
+
+function test_partial_loading_field_without_comparing(load_func, field) {
+    console.log('test_partial_loading_field_without_comparing ...');
+    let data = load_func(0, ckb.SOURCE_INPUT, field);
+    console.assert(data);
+    let length = load_func(0, ckb.SOURCE_INPUT, field, 0);
+    console.assert(length > 0);
+    length = load_func(0, ckb.SOURCE_INPUT, field, 0, 1);
+    console.assert(length > 0);
+    data = load_func(0, ckb.SOURCE_INPUT, field, 7);
+    console.assert(data);
+    data = load_func(0, ckb.SOURCE_INPUT, field, 7, 1);
+    console.assert(data);
+
+    must_throw_exception(() => {
+        load_func(1001n, ckb.SOURCE_INPUT, field);
+    });
+    must_throw_exception(() => {
+        load_func(0, ckb.SOURCE_INPUT + 1000n, field);
+    });
+    console.log('test_partial_loading_field_without_comparing done');
+}
+
+function test_misc() {
+    console.log("test_misc ....");
+    let hash = ckb.load_tx_hash();
+    console.assert(hash.byteLength == 32);
+    hash = ckb.load_script_hash();
+    console.assert(hash.byteLength == 32);
+    let version = ckb.vm_version();
+    console.assert(version >= 0);
+    let cycles = ckb.current_cycles();
+    console.assert(cycles > 0);
+    let cycles2 = ckb.current_cycles();
+    console.assert(cycles2 > cycles);
+    console.log("test_misc done");
+}
+
+test_misc();
+test_partial_loading(ckb.load_witness);
+test_partial_loading(ckb.load_cell_data);
+test_partial_loading_without_comparing(ckb.load_witness);
+test_partial_loading_without_comparing(ckb.load_cell_data);
+test_partial_loading_without_comparing(ckb.load_transaction);
+test_partial_loading_without_comparing(ckb.load_script);
+test_partial_loading_without_comparing(ckb.load_cell);
+test_partial_loading_field_without_comparing(ckb.load_cell_by_field, ckb.CELL_FIELD_CAPACITY);
+test_partial_loading_field_without_comparing(ckb.load_input_by_field, ckb.INPUT_FIELD_OUT_POINT);
+
+ckb.exit(0);

--- a/tests/ckb_js_tests/test_data/syscall.js
+++ b/tests/ckb_js_tests/test_data/syscall.js
@@ -1,16 +1,6 @@
 
 
 const ARRAY8 = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-
-function into_array_buffer(input) {
-    let ret = new ArrayBuffer(input.length);
-    let view = new Uint8Array(ret);
-    for (let i = 0; i < input.length; i++) {
-        view[i] = input[i];
-    }
-    return ret;
-}
-
 function expect_array(a, b) {
     if (a.byteLength != b.length) {
         console.assert(false, `expect_array failed: length mismatched, ${a} VS ${b}`);
@@ -117,19 +107,11 @@ function test_misc() {
 function test_spawn() {
     console.log('test_spawn ...');
     const js_code = `
-    function into_array_buffer(input) {
-        let ret = new ArrayBuffer(input.length);
-        let view = new Uint8Array(ret);
-        for (let i = 0; i < input.length; i++) {
-            view[i] = input[i];
-        }
-        return ret;
-    }    
-    let c = into_array_buffer([0,1,2,3,4,5,6,7]);
+    let c = new Uint8Array([0,1,2,3,4,5,6,7]);
     ckb.set_content(c);
     ckb.exit(0);
     `;
-    let code_hash = into_array_buffer([
+    let code_hash = new Uint8Array([
         0xdf, 0x97, 0x77, 0x78, 0x08, 0x9b, 0xf3, 0x3f, 0xc5, 0x1f, 0x22, 0x45, 0xfa, 0x6d, 0xb7, 0xfa,
         0x18, 0x19, 0xd5, 0x03, 0x11, 0x31, 0xa8, 0x3d, 0x4e, 0xcb, 0xcb, 0x6c, 0xba, 0x07, 0xce, 0x91
     ]);

--- a/tests/ckb_js_tests/test_data/syscall.js
+++ b/tests/ckb_js_tests/test_data/syscall.js
@@ -26,6 +26,8 @@ function test_partial_loading(load_func) {
     console.log('test_partial_loading ...');
     let data = load_func(0, ckb.SOURCE_OUTPUT);
     expect_array(data, ARRAY8);
+    data = load_func(0, ckb.SOURCE_OUTPUT, 100);
+    expect_array(data, ARRAY8);
     let length = load_func(0, ckb.SOURCE_OUTPUT, 0);
     console.assert(length === 8, 'length != 8');
     length = load_func(0, ckb.SOURCE_OUTPUT, 0, 1);

--- a/tests/examples/Makefile
+++ b/tests/examples/Makefile
@@ -1,21 +1,22 @@
 
 CKB-DEBUGGER := ckb-debugger
-ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+BIN_PATH := $(ROOT_DIR)/../../build/ckb-js-vm
 
 MAX-CYCLES ?= 2000000000
 TEST-FILE ?=
 
 define run
-	$(CKB-DEBUGGER) --max-cycles $(MAX-CYCLES) --read-file $(ROOT_DIR)/$(1) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -r  2>&1 | fgrep 'Run result: 0'
+	$(CKB-DEBUGGER) --max-cycles $(MAX-CYCLES) --read-file $(ROOT_DIR)/$(1) --bin $(BIN_PATH) -- -r  2>&1 | fgrep 'Run result: 0'
 endef
 
 define debug
-	$(CKB-DEBUGGER) --max-cycles $(MAX-CYCLES) --read-file $(ROOT_DIR)/$(1) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -r
+	$(CKB-DEBUGGER) --max-cycles $(MAX-CYCLES) --read-file $(ROOT_DIR)/$(1) --bin $(BIN_PATH) -- -r
 endef
 
 define compile-run
-	$(CKB-DEBUGGER) --read-file $(ROOT_DIR)/$(1) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -c | awk '/Run result: 0/{exit} {print}' | xxd -r -p > $(ROOT_DIR)/../../build/$(1).bc
-	$(CKB-DEBUGGER) --read-file $(ROOT_DIR)/../../build/$(1).bc --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -r | fgrep 'Run result: 0'
+	$(CKB-DEBUGGER) --read-file $(ROOT_DIR)/$(1) --bin $(BIN_PATH) -- -c | awk '/Run result: 0/{exit} {print}' | xxd -r -p > $(ROOT_DIR)/../../build/$(1).bc
+	$(CKB-DEBUGGER) --read-file $(ROOT_DIR)/../../build/$(1).bc --bin $(BIN_PATH) -- -r | fgrep 'Run result: 0'
 endef
 
 all:

--- a/tests/examples/Makefile
+++ b/tests/examples/Makefile
@@ -14,7 +14,7 @@ define debug
 endef
 
 define compile-run
-	$(CKB-DEBUGGER) --read-file $(ROOT_DIR)/$(1) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -c | head -n -3 | xxd -r -p > $(ROOT_DIR)/../../build/$(1).bc
+	$(CKB-DEBUGGER) --read-file $(ROOT_DIR)/$(1) --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -c | awk '/Run result: 0/{exit} {print}' | xxd -r -p > $(ROOT_DIR)/../../build/$(1).bc
 	$(CKB-DEBUGGER) --read-file $(ROOT_DIR)/../../build/$(1).bc --bin $(ROOT_DIR)/../../build/ckb-js-vm -- -r | fgrep 'Run result: 0'
 endef
 


### PR DESCRIPTION
The JS syscall bindings follow lua bindings: https://github.com/nervosnetwork/ckb-lua-vm/blob/master/docs/dylib.md#appendix-exported-lua-functions-and-constants-in-the-ckb-module
